### PR TITLE
DP-1690 dnsflow mtu handling

### DIFF
--- a/dnsflow.c
+++ b/dnsflow.c
@@ -943,13 +943,15 @@ dnsflow_pkt_build(struct in_addr* client_ip, struct in6_addr* client_ip6, struct
 	set_len += ips_len_total;
 	set_len += ip6s_len_total;
 	/* This set will not fit in any dnsflow pkt*/
-	if (set_len > MTU - sizeof(dnsflow_hdr)) {
+	_log("Estimated set length: %u\n", set_len);
+    _log("Remaining size in the pkt: %u\n", pkt_end - pkt_cur);
+	if (set_len > MTU - sizeof(dnsflow_hdr) + 1) {
 		warnx("set too big, doesn't fit in MTU");
 		data_buf->db_len = 0;
 		return;
 	}
 	/* This set will fit in the remainder of this dnsflow pkt*/
-	if (set_len < pkt_end - pkt_cur) {
+	if (set_len < pkt_end - pkt_cur + 1) {
 		/* Start building new set. */
 		set_hdr = (struct dnsflow_set_hdr *)pkt_cur;
 		bzero(set_hdr, sizeof(struct dnsflow_set_hdr));

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -1138,6 +1138,9 @@ signal_cb(int signal, short event, void *arg)
 
 	switch (signal) {
 	case SIGINT:
+		_log("received SIGINT");
+		clean_exit(dcap);
+		break;
 	case SIGTERM:
 		_log("received exit signal: %d", signal);
 		clean_exit(dcap);	/* Doesn't return. */

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -946,7 +946,6 @@ dnsflow_pkt_build(struct in_addr* client_ip, struct in6_addr* client_ip6, struct
 
 	/* This set will not fit in any dnsflow pkt*/
 	if (set_len > DNSFLOW_PKT_MAX_SIZE - sizeof(dnsflow_hdr) + 1) {
-		warnx("set too big exceeding Ethernet MTU");
 		return;
 	}
 	/* This set will fit in the remainder of this dnsflow pkt*/

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -906,11 +906,13 @@ dnsflow_pkt_build(struct in_addr* client_ip, struct in6_addr* client_ip6, struct
 	struct dnsflow_hdr		*dnsflow_hdr;
 	struct dnsflow_set_hdr		*set_hdr;
 	char			        *pkt_start, *pkt_cur, *pkt_end, *names_start;
-	int				i;
+	int				i, j;
 	int				header_len = 0;
 	struct in_addr			*ip_ptr;
 	struct in6_addr			*ip6_ptr;
-	int 				set_len;
+	int 				set_len, ips_len_total, ip6s_len_total;
+	int 				name_len_total = 0;
+	uint8_t 			names_count, ips_count, ip6s_count;
 
 	dnsflow_hdr = &data_buf->db_pkt_hdr;
 	pkt_start = (char *)dnsflow_hdr;
@@ -926,21 +928,19 @@ dnsflow_pkt_build(struct in_addr* client_ip, struct in6_addr* client_ip6, struct
 
 	/* Estimate length of set to see if it fits in this pkt*/
 	set_len = sizeof(struct dnsflow_set_hdr);
-	// Move declaration to top
-	int name_len_total = 0;
-	uint8_t names_count = 
+	
+	names_count = 
 		MIN(dns_data->num_names, DNSFLOW_NAMES_COUNT_MAX);
-	uint8_t ips_count = 
+	ips_count = 
 		MIN(dns_data->num_ips, DNSFLOW_IPS_COUNT_MAX);
-	uint8_t ip6s_count = 
+	ip6s_count = 
 		MIN(dns_data->num_ip6s, DNSFLOW_IPS_COUNT_MAX);
-	int j;
 	for (j = 0; j < names_count; j++) {
 		name_len_total += dns_data->name_lens[j];
 	}
 	set_len += name_len_total;
-	int ips_len_total = ips_count * sizeof(struct in_addr);
-	int ip6s_len_total = ip6s_count * sizeof(struct in6_addr);
+	ips_len_total = ips_count * sizeof(struct in_addr);
+	ip6s_len_total = ip6s_count * sizeof(struct in6_addr);
 	set_len += ips_len_total;
 	set_len += ip6s_len_total;
 

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -278,7 +278,7 @@ dnsflow_print_stats(struct dcap_stat *ds)
 {
 	_log("%u packets captured", ds->captured);
 	_log("%u packets oversized", oversize_pkt);
-	_log("%u set-boundary split happened", split_cnt)
+	_log("%u set-boundary split happened", split_cnt);
 	if (ds->ps_valid) {
 		_log("%u packets received by filter", ds->ps_recv);
 		_log("%u packets dropped by kernel", ds->ps_drop);
@@ -919,7 +919,7 @@ dnsflow_pkt_build(struct in_addr* client_ip, struct in6_addr* client_ip6, struct
 	struct in_addr			*ip_ptr;
 	struct in6_addr			*ip6_ptr;
 	int 				set_len;
-	oversize_pkt++;
+
 	dnsflow_hdr = &data_buf->db_pkt_hdr;
 	pkt_start = (char *)dnsflow_hdr;
 	if (data_buf->db_len == 0) {
@@ -954,6 +954,7 @@ dnsflow_pkt_build(struct in_addr* client_ip, struct in6_addr* client_ip6, struct
 
 	/* This set will not fit in any dnsflow pkt*/
 	if (set_len > DNSFLOW_PKT_MAX_SIZE - sizeof(dnsflow_hdr) + 1) {
+		oversize_pkt++;
 		warnx("set too big exceeding Ethernet MTU");
 		return;
 	}

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -105,7 +105,7 @@
 
 #define DNSFLOW_MAX_PARSE		255
 #define DNSFLOW_PKT_MAX_SIZE		65535
-#define MTU 					1500
+#define MTU 				1500
 #define DNSFLOW_PKT_TARGET_SIZE		1200
 #define DNSFLOW_VERSION			4
 #define DNSFLOW_PORT			5300
@@ -885,6 +885,7 @@ dnsflow_pkt_send_data()
 	if (data_buf->db_len >= MTU) {
 		_log("packet-exceeds-mtu: %d", data_buf->db_len);
 	}
+	_log("%d", data_buf->db_len);
 	data_buf->db_pkt_hdr.sequence_number = htonl(sequence_number++);
 	dnsflow_pkt_send(data_buf);
 	data_buf->db_len = 0;
@@ -913,7 +914,7 @@ dnsflow_pkt_build(struct in_addr* client_ip, struct in6_addr* client_ip6, struct
 	int				header_len = 0;
 	struct in_addr			*ip_ptr;
 	struct in6_addr			*ip6_ptr;
-	int 			set_len;
+	int 				set_len;
 	
 	dnsflow_hdr = &data_buf->db_pkt_hdr;
 	pkt_start = (char *)dnsflow_hdr;
@@ -929,6 +930,7 @@ dnsflow_pkt_build(struct in_addr* client_ip, struct in6_addr* client_ip6, struct
 
 	/* Estimate length of set to see if it fits in this pkt*/
 	set_len = sizeof(struct dnsflow_set_hdr);
+	// Move declaration to top
 	int name_len_total = 0;
 	uint8_t names_count = 
 		MIN(dns_data->num_names, DNSFLOW_NAMES_COUNT_MAX);
@@ -949,7 +951,6 @@ dnsflow_pkt_build(struct in_addr* client_ip, struct in6_addr* client_ip6, struct
 	/* This set will not fit in any dnsflow pkt*/
 	if (set_len > MTU - sizeof(dnsflow_hdr) + 1) {
 		warnx("set too big, doesn't fit in MTU");
-		data_buf->db_len = 0;
 		return;
 	}
 	/* This set will fit in the remainder of this dnsflow pkt*/

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -942,9 +942,8 @@ dnsflow_pkt_build(struct in_addr* client_ip, struct in6_addr* client_ip6, struct
 	int ip6s_len_total = ip6s_count * sizeof(struct in6_addr);
 	set_len += ips_len_total;
 	set_len += ip6s_len_total;
+
 	/* This set will not fit in any dnsflow pkt*/
-	_log("Estimated set length: %u\n", set_len);
-    _log("Remaining size in the pkt: %u\n", pkt_end - pkt_cur);
 	if (set_len > MTU - sizeof(dnsflow_hdr) + 1) {
 		warnx("set too big, doesn't fit in MTU");
 		data_buf->db_len = 0;

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -927,11 +927,11 @@ dnsflow_pkt_build(struct in_addr* client_ip, struct in6_addr* client_ip6, struct
 	/* Estimate length of set to see if it fits in this pkt*/
 	set_len = sizeof(struct dnsflow_set_hdr);
 	int name_len_total = 0;
-	int names_count = 
+	uint8_t names_count = 
 		MIN(dns_data->num_names, DNSFLOW_NAMES_COUNT_MAX);
-	int ips_count = 
+	uint8_t ips_count = 
 		MIN(dns_data->num_ips, DNSFLOW_IPS_COUNT_MAX);
-	int ip6s_count = 
+	uint8_t ip6s_count = 
 		MIN(dns_data->num_ip6s, DNSFLOW_IPS_COUNT_MAX);
 	int j;
 	for (j = 0; j < names_count; j++) {

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -217,6 +217,7 @@ static struct dnsflow_buf	*data_buf = NULL;
 static time_t			last_send = 0;
 static uint32_t			oversize_pkt = 0;
 static uint32_t 		split_cnt = 0;
+static uint32_t 		pkt_sent = 0;
 
 static struct event		push_ev;
 static struct timeval		push_tv = {1, 0};
@@ -279,6 +280,7 @@ dnsflow_print_stats(struct dcap_stat *ds)
 	_log("%u packets captured", ds->captured);
 	_log("%u packets oversized", oversize_pkt);
 	_log("%u set-boundary split happened", split_cnt);
+	_log("%u dnsflow pkt sent", pkt_sent);
 	if (ds->ps_valid) {
 		_log("%u packets received by filter", ds->ps_recv);
 		_log("%u packets dropped by kernel", ds->ps_drop);
@@ -889,6 +891,7 @@ dnsflow_pkt_send_data()
 	if (data_buf->db_len >= DNSFLOW_PKT_MAX_SIZE) {
 		_log("packet-exceeds-mtu: %d", data_buf->db_len);
 	}
+	pkt_sent++;
 	//_log("%d", data_buf->db_len);
 	data_buf->db_pkt_hdr.sequence_number = htonl(sequence_number++);
 	dnsflow_pkt_send(data_buf);

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -883,7 +883,7 @@ dnsflow_pkt_send_data()
 		return;
 	}
 	if (data_buf->db_len >= MTU) {
-		_log("%d", data_buf->db_len);
+		_log("packet-exceeds-mtu: %d", data_buf->db_len);
 	}
 	data_buf->db_pkt_hdr.sequence_number = htonl(sequence_number++);
 	dnsflow_pkt_send(data_buf);
@@ -1017,7 +1017,7 @@ dnsflow_pkt_build(struct in_addr* client_ip, struct in6_addr* client_ip6, struct
 	}
 	/* This set will fit in the next dnsflow pkt*/
 	else {
-		_log("/* This set will fit in the next dnsflow pkt*/");
+		_log("next-set-wont-fit: this curr size %d, next set size %d", data_buf->db_len, set_len);
 		/* Send and reset data buffer len */
 		dnsflow_pkt_send_data();
 		/* Start a new packet*/

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -1127,9 +1127,6 @@ signal_cb(int signal, short event, void *arg)
 
 	switch (signal) {
 	case SIGINT:
-		_log("received SIGINT");
-		clean_exit(dcap);
-		break;
 	case SIGTERM:
 		_log("received exit signal: %d", signal);
 		clean_exit(dcap);	/* Doesn't return. */


### PR DESCRIPTION
[Addresses DP-1690](https://deepfield.atlassian.net/browse/DP-1690)

----
## The Problem
Previously, the dnsflow daemon assumes DNSFlow protocol packet max size to be 65535 and attempts to send packets over the Ethernet MTU of 1500 anyways

## Why This Solution?
Before inserting results parsed from a dns packet (a dns_data_set), calculate its size and see if it will fit in the rest of the dnsflow packet (or fit in any dnsflow packet at all). If not, send the current packet and start a new dnsflow packet to accomodate this large dns_data_set.
New build logic: 
```
calculate set_len

/* This set alone will not fit in any dnsflow packet */
if set_len > MTU:
    warn("will never fit")
    return

/* Will fit in the remainder of this packet*/
if set_len < MTU - curr_data_buffer_len:
    do normal append to curr pkt stuff (will send if accumulated enough)
/* Won't fit in this dnsflow pkt but will fit in next one*/
else
    send this one, which also resets current packet
    build packet again into a new data_buffer
```

<!--
----
### How to Test
1.
2.
-->

<!--
### Screenshots
#### Before
#### After
-->

