### PR TITLE
CDT-223: parallel filter improvements, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
  * [Build DNSFlow](#building-dnsflow-daemon)
  * [Running](#running)
  * [Running as an Upstart job](#running-as-an-upstart-job)
+ * [High-Flow Multi-Process Performance](#high-flow-multi-process-performance)
 
-## Running 
+## Running
 After you get it built, start the daemon that will forward the DNS (to the localhost in this case):
 ```
 ./dnsflow -i eth0 -u 127.0.0.1 -P /tmp/dnsflow.pid
@@ -30,7 +31,7 @@ Read the packets being sent to the local host:
 ```
 
 ## Running as an Upstart job
-Running as an Upstart job requires DNSFlow to be installed on a Ubuntu/Debian deployment. These commands should be run with root priviledges.
+Running as an Upstart job requires DNSFlow to be installed on a Ubuntu/Debian deployment. These commands should be run with root privileges.
 
 Starting DNSFlow.
 ```
@@ -52,10 +53,51 @@ Command line options, pid file location, and DNSFlow binary location can be spec
 /etc/default/dnsflow
 ```
 
+## High-Flow Multi-Process Performance
+
+When running in multi-process mode (using -M <nprocs>), it is
+important to consider both the hardware capabilities of the machine
+you are running on and the characteristics of the processes that are
+running. For this application, although processes must wait for
+packets to arrive over the network, in high-flow situations these
+dnsflow processes are CPU hungry. Thus, in the common case of running
+on multi-core, shared-memory, commodity-hardware machine (e.g., 32
+cores, 64 GB of RAM), it does not make sense to set the number of
+processes to more than the number of CPUs. Typically, the ideal number
+of processes is roughly **half of the number of CPUs**, as the CPUs
+themselves also share hardware resources. This can be set
+automatically with `-M 0`.
+
+Along with the number processes, the share of packets consumed by each
+process is important. The default multi-processing filter distributes
+packets based on a modulo of the DNS response destination for ipv4
+addresses, and the UDP checksum for ipv6 DNS responses. This can be
+good enough in moderate flow situations, but may result in packets
+being lost if flow is high and not evenly distributed over client ipv4
+addresses. The `-c` option activates a new multi-process filter that
+utilizes the ipv4 checksum when it is available, falling back to the
+default ipv4 filter when it is not. This balancing mode tends to
+provide better load balance over many processes, which may result in
+fewer packets being dropped.
+
+If you would like automatically apply the recommended high-performance
+settings discussed above, launch the application with the following
+two additional options:
+```
+sudo ./dnsflow .. -c -M 0
+```
+
+If you suspect additional speedup is possible by utilizing more than
+half of the available CPUs, we recommend you verify this by examining
+the total time to process a large pcap file under different -M
+settings on the target machine. A good procedure is to start with a
+small setting for M, then doubling it until the total processing time no
+longer decreases.
+
 ## Install DNSFlow Reader Dependencies
 The dnsflow reader is a python script with the following dependencies:
 
-Install the python package installer pip (via apt on ubuntu).
+Install the python package installer pip (via apt on Ubuntu).
 ```
 sudo apt-get install python-pip
 ```
@@ -143,4 +185,3 @@ the CentOS / RedHat 7 RPM
    edit destination IP and interface
 > sudo service dnsflow start
 ```
-   

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ default ipv4 filter when it is not. This balancing mode tends to
 provide better load balance over many processes, which may result in
 fewer packets being dropped.
 
-If you would like automatically apply the recommended high-performance
-settings discussed above, launch the application with the following
-two additional options:
+If you would like to automatically apply the recommended
+high-performance settings discussed above, launch the application with
+the following two additional options:
 ```
 sudo ./dnsflow .. -c -M 0
 ```
@@ -91,8 +91,8 @@ If you suspect additional speedup is possible by utilizing more than
 half of the available CPUs, we recommend you verify this by examining
 the total time to process a large pcap file under different -M
 settings on the target machine. A good procedure is to start with a
-small setting for M, then doubling it until the total processing time no
-longer decreases.
+small setting for M, and then double it until the total processing
+time no longer decreases.
 
 ## Install DNSFlow Reader Dependencies
 The dnsflow reader is a python script with the following dependencies:

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -66,7 +66,6 @@
 #include <sys/sysinfo.h>
 #if __linux__
 #include <sys/prctl.h>
-#include <linux/version.h>
 #endif
 #include <inttypes.h>
 #include <errno.h>
@@ -444,36 +443,13 @@ build_pcap_filter(int encap_offset, int proc_i, int num_procs, int enable_mdns, 
 		 * each client in same stream. Another possibility would be
 		 * the udp checksum, assuming it's set.  */
 		if (enable_checksum_mproc_filter) {
-#if __linux__ && (LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,0))
 			snprintf(multi_proc_filter, sizeof(multi_proc_filter),
-				 "(ip and (%s) and (((ip[%d:4] %% %u) + (udp[%d:2] %% %u)) %% %u = %u)) or ",
+				 "(ip and (%s) and (((udp[%d:2] != 0) and ((udp[%d:2] - udp[%d:2]/%u*%u) = %u)) or ((udp[%d:2] = 0) and ((ip[%d:4] - ip[%d:4]/%u*%u) = %u)))) or ",
 				 dns_resp_filter,
-				 dst_ip_offset + ip_offset, num_procs,
-				 checksum_udp_offset, num_procs,
-				 num_procs, proc_i - 1);
-#else
-			snprintf(multi_proc_filter, sizeof(multi_proc_filter),
-				 "(ip and (%s) and (((ip[%d:4] - ip[%d:4]/%u*%u) + (udp[%d:2] - udp[%d:2]/%u*%u)) - ((ip[%d:4] - ip[%d:4]/%u*%u) + (udp[%d:2] - udp[%d:2]/%u*%u))/%u*%u = %u)) or ",
-				 dns_resp_filter,
-				 dst_ip_offset + ip_offset, dst_ip_offset + ip_offset, num_procs, num_procs,
-				 checksum_udp_offset, checksum_udp_offset, num_procs, num_procs,
-				 dst_ip_offset + ip_offset, dst_ip_offset + ip_offset, num_procs, num_procs,
-				 checksum_udp_offset, checksum_udp_offset, num_procs, num_procs,
-				 num_procs, num_procs, proc_i - 1);
-#endif
+				 checksum_udp_offset, checksum_udp_offset, checksum_udp_offset, num_procs, num_procs, proc_i - 1,
+				 checksum_udp_offset, dst_ip_offset + ip_offset, dst_ip_offset + ip_offset, num_procs, num_procs, proc_i - 1);
 			cp = multi_proc_filter;
 			cp += strlen(multi_proc_filter);
-
-#if __linux__ && (LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,0))
-			snprintf(cp, sizeof(multi_proc_filter) - (cp - multi_proc_filter),
-				 "(ip6 and %s and (ip6[%d:2] %% %u = %u))",
-				 dns_resp_filter, ip6_offset + checksum_udp_offset, num_procs, proc_i - 1);
-#else
-			snprintf(cp, sizeof(multi_proc_filter) - (cp - multi_proc_filter),
-				 "(ip6 and %s and (ip6[%d:2] - ip6[%d:2] / %u * %u = %u))",
-				 dns_resp_filter, ip6_offset + checksum_udp_offset,
-				 ip6_offset + checksum_udp_offset, num_procs, num_procs, proc_i - 1);
-#endif
 		} else {
 			snprintf(multi_proc_filter, sizeof(multi_proc_filter),
 				 "(ip and %s and (ip[%d:4] - ip[%d:4] / %u * %u = %u)) or ",
@@ -481,12 +457,11 @@ build_pcap_filter(int encap_offset, int proc_i, int num_procs, int enable_mdns, 
 				 dst_ip_offset + ip_offset, num_procs, num_procs, proc_i - 1);
 			cp = multi_proc_filter;
 			cp += strlen(multi_proc_filter);
-
-			snprintf(cp, sizeof(multi_proc_filter) - (cp - multi_proc_filter),
-				 "(ip6 and %s and (ip6[%d:2] - ip6[%d:2] / %u * %u = %u))",
-				 dns_resp_filter, ip6_offset + checksum_udp_offset,
-				 ip6_offset + checksum_udp_offset, num_procs, num_procs, proc_i - 1);
 		}
+		snprintf(cp, sizeof(multi_proc_filter) - (cp - multi_proc_filter),
+			 "(ip6 and %s and (ip6[%d:2] - ip6[%d:2] / %u * %u = %u))",
+			 dns_resp_filter, ip6_offset + checksum_udp_offset,
+			 ip6_offset + checksum_udp_offset, num_procs, num_procs, proc_i - 1);
 	} else {
 		/* Just copy base dns filter. */
 		snprintf(multi_proc_filter, sizeof(multi_proc_filter), "%s", dns_resp_filter);

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -473,15 +473,15 @@ char *
 ts_format(struct timeval *ts)
 {
 	int		sec, usec;
-        static char	buf[256];
+	static char	buf[256];
 
        	sec = ts->tv_sec % 86400;
 	usec = ts->tv_usec;
 
-        snprintf(buf, sizeof(buf), "%02d:%02d:%02d.%06u",
-               sec / 3600, (sec % 3600) / 60, sec % 60, usec);
+	snprintf(buf, sizeof(buf), "%02d:%02d:%02d.%06u",
+		 sec / 3600, (sec % 3600) / 60, sec % 60, usec);
 
-        return buf;
+	return buf;
 }
 
 /**

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -451,10 +451,10 @@ build_pcap_filter(int encap_offset, int proc_i, int num_procs, int enable_mdns, 
 		 */
 		/* Note about performance:
 		 *  - We avoid explicit use of the % operator, and instead
-		 *    express x % y as (x - x/y*y) for integers x, y. According
+		 *    express (x % y) as (x - x/y*y) for integers x, y. According
 		 *    to the pcap-filter(7) man page, the % and ^ operators
 		 *    have limited support in some kernels (older or non-linux),
-		 *    when can have severe performance impacts.
+		 *    which can have severe performance impacts.
 		 */
 		if (!enable_ipv4_checksum_mproc_filter) {
 			snprintf(multi_proc_filter, sizeof(multi_proc_filter),


### PR DESCRIPTION
**Quick note**:
 - The only change in default behavior of this application is that running more processes than available CPUs ~~requires the use of a new command-line option.~~ is not allowed.

**Summary of Changes**:
 - Replace assert with explicit error when starting with more than 64 processes
 - ~~Add new `-o` option that is required when starting with more processes than available CPUs. This scenario very likely degrades performance, and should likely only be used to verify that this is true.~~
 - Using `-M 0` sets the number of processes to half the available CPUs.
   - Available CPUs are obtained from `<sys/sysinfo.h> -> get_nprocs()`.
 - Add new `-c` option that uses a checksum-based multi-proc filter for ipv4 dns packets. (See discussion section below)
   - ~~Use `%` operator in the pcap filter expression when the linux kernel supports it, as this provides a 15% improvement in performance for this new filter.~~

**Justification for New Multiprocessing Filter (-c option)**

The figures shown below are based on a 1 minute tcpdump of dns response packets from telefonica, provided by Ato. (11 GB, ~54 million packets, 99% ipv4, 1% ipv6)

The default multiprocessing filter can be summarized as follows, where `p` is the process id a packet gets assigned to:
```python
if ipv4:
   p = <destination_ip> % nproc
elif ipv6:
   p = <udp_checksum> % nproc
```
This results in the following packet load distribution over 64 processes for the telefonica test dump:
![filter1](https://user-images.githubusercontent.com/52933501/81191767-64a34500-8f87-11ea-8f9d-f9a05fe58b7e.png)

If we utilize the checksum for ipv4 packets instead of the destination ip address, the filter looks like the following:
```python
p = <udp_checksum> % nproc
```
This results in a very clear improvement to packet load distribution for this test data over the same number of processes:
![filter2](https://user-images.githubusercontent.com/52933501/81192465-4427ba80-8f88-11ea-8d67-b76cfaa8ffdb.png)

Finally, it is important to note that for ipv4 udp packets, the checksum is optional (which can explain the small amount of bias to process 0 in the last figure). To overcome this, especially in networks where the checksum may rarely be set for ipv4 udp packets, this PR implements a mixing of the above two approaches for ipv4:
```python
p = <udp_checksum> % nproc
if ipv4:
   p += (<destination_ip> % nproc)
   p = p % nproc
```
The packet load distribution for this final filter on the test becomes:
![filter3](https://user-images.githubusercontent.com/52933501/81193605-96b5a680-8f89-11ea-9254-1bf3983e0c21.png)

Update: the above filter is no longer used, see later comments for final filter along with load balance graph.

