### PR TITLE
DP-2798 python3 compatibility + switch to pypcap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .DS_Store
 .deps
 tags
+.idea/*

--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ Install python pip modules for dpkt and ipaddr.
 sudo pip install dpkt ipaddr
 ```
 
-Install [pypcap](https://github.com/pynetwork/pypcap).
+Install [pypcap](https://github.com/pynetwork/pypcap). 
+
+Note: Previously (with python2) the [python-libpcap](http://sourceforge.net/projects/pylibpcap/files/pylibpcap/0.6.4)
+was used, and both modules are imported into python with the same name. 
+So, the python-libcpap may need to first be uninstalled to prevent the naming conflict.
 ```
 sudo pip install pypcap
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ small setting for M, and then double it until the total processing
 time no longer decreases.
 
 ## Install DNSFlow Reader Dependencies
-The dnsflow reader is a python script with the following dependencies:
+The dnsflow reader is a python3 script with the following dependencies:
 
 Install the python package installer pip (via apt on Ubuntu).
 ```
@@ -107,11 +107,9 @@ Install python pip modules for dpkt and ipaddr.
 sudo pip install dpkt ipaddr
 ```
 
-Download [python-libpcap](http://sourceforge.net/projects/pylibpcap/files/pylibpcap/0.6.4).
+Install [pypcap](https://github.com/pynetwork/pypcap).
 ```
-tar xvfz pylibpcap-0.6.4.tar.gz
-cd pylibpcap-0.6.4
-sudo python ./setup.py install
+sudo pip install pypcap
 ```
 
 ## Building DNSFlow daemon

--- a/dnsflow_read.py
+++ b/dnsflow_read.py
@@ -10,11 +10,20 @@ import argparse
 import gzip
 import socket
 import dpkt
-import pcap
 import struct
+import sys
 import ipaddr
 from dpkt.ip import IP_PROTO_UDP
 from dpkt.udp import UDP
+
+try:
+    import pcap
+except ImportError:
+    print(
+        "Could not import the 'pcap' module.\n"
+        "Please see README for dependency instructions and ensure pypcap (not python-libpcap) is installed."
+    )
+    sys.exit(-1)
 
 DNSFLOW_FLAG_STATS = 0x0001
 DEFAULT_PCAP_FILTER = "udp and dst port 5300"

--- a/dnsflow_read.py
+++ b/dnsflow_read.py
@@ -80,7 +80,7 @@ class reader(object):
             pkt, err = process_pkt(self._pcap.datalink(), ts, buf,
                     stats_only=self.stats_only)
             if err is not None:
-                print err
+                print(err)
                 continue
             yield pkt
 
@@ -132,7 +132,7 @@ def process_pkt(dl_type, ts, buf, stats_only=False):
     try:
         vers, sets_count, flags, seq_num = struct.unpack(fmt,
                 dnsflow_pkt[cp:cp + struct.calcsize(fmt)])
-    except struct.error, e:
+    except struct.error as e:
         err = 'PARSE_ERROR|%s|%s' % (fmt, e)
         return (pkt, err)
     cp += struct.calcsize(fmt)
@@ -160,7 +160,7 @@ def process_pkt(dl_type, ts, buf, stats_only=False):
         try:
             stats = struct.unpack(fmt,
                     dnsflow_pkt[cp:cp + struct.calcsize(fmt)])
-        except struct.error, e:
+        except struct.error as e:
             err = 'HEADER_PARSE_ERROR|%s|%s' % (fmt, e)
             return (pkt, err)
         sp = {}
@@ -243,7 +243,7 @@ def process_pkt(dl_type, ts, buf, stats_only=False):
                             dnsflow_pkt[cp:cp + struct.calcsize(fmt)])
                     client_ip, names_count, ips_count, names_len = vals
 
-            except struct.error, e:
+            except struct.error as e:
                 err = 'DATA_PARSE_ERROR|%s|%s' % (fmt, e)
                 return (pkt, err)
             cp += struct.calcsize(fmt)
@@ -256,7 +256,7 @@ def process_pkt(dl_type, ts, buf, stats_only=False):
             try:
                 name_set = struct.unpack(fmt,
                         dnsflow_pkt[cp:cp + struct.calcsize(fmt)])[0]
-            except struct.error, e:
+            except struct.error as e:
                 err = 'DATA_PARSE_ERROR|%s|%s' % (fmt, e)
                 return (pkt, err)
             cp += struct.calcsize(fmt)
@@ -294,7 +294,7 @@ def process_pkt(dl_type, ts, buf, stats_only=False):
             try:
                 ips = struct.unpack(fmt,
                         dnsflow_pkt[cp:cp + struct.calcsize(fmt)])
-            except struct.error, e:
+            except struct.error as e:
                 err = 'DATA_PARSE_ERROR|%s|%s' % (fmt, e)
                 return (pkt, err)
             cp += struct.calcsize(fmt)
@@ -307,7 +307,7 @@ def process_pkt(dl_type, ts, buf, stats_only=False):
                     try:
                         ipval = list(struct.unpack(fmt,
                                 dnsflow_pkt[cp:cp + struct.calcsize(fmt)]))
-                    except struct.error, e:
+                    except struct.error as e:
                         err = 'DATA_PARSE_ERROR|%s|%s' % (fmt, e)
                         return (pkt, err)
                     cp += struct.calcsize(fmt)
@@ -334,7 +334,7 @@ def process_pkt(dl_type, ts, buf, stats_only=False):
 # Deprecated.
 def read_pcapfiles(pcap_files, pcap_filter, callback):
     for pcap_file in pcap_files:
-        print 'FILE|%s' % (pcap_file)
+        print('FILE|%s' % (pcap_file))
         # XXX dpkt pcap doesn't support filters and there's no way to pass
         # a gzip fd to pylibpcap. Bummer.
         p = pcap.pcapObject()
@@ -351,13 +351,13 @@ def read_pcapfiles(pcap_files, pcap_filter, callback):
             pktlen, buf, ts = rv
             pkt, err = process_pkt(p.datalink(), ts, buf)
             if err is not None:
-                print err
+                print(err)
                 continue
             callback(pkt)
 
 # Deprecated.
 def mode_livecapture(interface, pcap_filter, callback):
-    print 'Capturing on', interface
+    print('Capturing on', interface)
     p = pcap.pcapObject()
     p.open_live(interface, 65535, 1, 100)
     # filter, optimize, netmask
@@ -370,13 +370,13 @@ def mode_livecapture(interface, pcap_filter, callback):
                 pktlen, buf, ts = rv
                 pkt, err = process_pkt(p.datalink(), ts, buf)
                 if err is not None:
-                    print err
+                    print(err)
                     continue
                 callback(pkt)
 
     except KeyboardInterrupt:
-        print '\nshutting down'
-        print '%d packets received, %d packets dropped, %d packets dropped by interface' % p.stats()
+        print('\nshutting down')
+        print('%d packets received, %d packets dropped, %d packets dropped by interface' % p.stats())
 
 def _print_parsed_pkt(pkt):
     hdr = pkt['header']
@@ -385,12 +385,12 @@ def _print_parsed_pkt(pkt):
 
     if 'stats' in pkt:
         stats = pkt['stats']
-        print "STATS|%s" % ('|'.join(['%s:%d' % (x[0], x[1])
-            for x in stats.items()]))
+        print("STATS|%s" % ('|'.join(['%s:%d' % (x[0], x[1])
+            for x in list(stats.items())])))
     else:
         for data in pkt['data']:
-            print '%s|%s|%s|%s|%s|%s|%s' % (hdr['src_ip_str'], data['resolver_ip'], data['client_ip'], tstr,
-                    ','.join(data['names']), ','.join(data['ips']), ','.join(data['ip6s']))
+            print('%s|%s|%s|%s|%s|%s|%s' % (hdr['src_ip_str'], data['resolver_ip'], data['client_ip'], tstr,
+                    ','.join(data['names']), ','.join(data['ips']), ','.join(data['ip6s'])))
 
 
 class SrcTracker(object):
@@ -423,11 +423,11 @@ class SrcTracker(object):
                 src['stats_last'] = pkt['stats']
                 src['stats_delta_last'] = {}
                 src['stats_delta_total'] = {}
-                for k in pkt['stats'].iterkeys():
+                for k in pkt['stats'].keys():
                     if k == 'sample_rate':
                         continue
                     src['stats_delta_total'][k] = 0
-            for k in pkt['stats'].iterkeys():
+            for k in pkt['stats'].keys():
                 if k == 'sample_rate':
                     continue
                 src['stats_delta_last'][k] = pkt['stats'][k] - src['stats_last'][k]
@@ -458,25 +458,25 @@ class SrcTracker(object):
     def print_summary_src(self, src_id):
         src = self.srcs[src_id]
         ts_delta = src['last_timestamp'] - src['first_timestamp']
-        print '%s:%s' % (src_id[0], src_id[1])
-        print '  %s' % (' '.join(['%s=%d' % (k, src[k])
-            for k in ['n_data_pkts', 'n_records', 'n_stats_pkts']]))
+        print('%s:%s' % (src_id[0], src_id[1]))
+        print('  %s' % (' '.join(['%s=%d' % (k, src[k])
+            for k in ['n_data_pkts', 'n_records', 'n_stats_pkts']])))
         if ts_delta > 0:
-            print '  %s' % (' '.join(['%s/s=%.2f' % (k, src[k]/ts_delta)
-                for k in ['n_data_pkts', 'n_records', 'n_stats_pkts']]))
+            print('  %s' % (' '.join(['%s/s=%.2f' % (k, src[k]/ts_delta)
+                for k in ['n_data_pkts', 'n_records', 'n_stats_pkts']])))
         if 'stats_delta_total' in src:
-            print '  %s' % (' '.join(['%s=%d' % (x[0], x[1])
-                for x in src['stats_delta_total'].items()]))
+            print('  %s' % (' '.join(['%s=%d' % (x[0], x[1])
+                for x in list(src['stats_delta_total'].items())])))
             if ts_delta > 0:
-                print '  %s' % (' '.join(['%s/s=%.2f' %
+                print('  %s' % (' '.join(['%s/s=%.2f' %
                     (x[0], x[1]/ts_delta)
-                    for x in src['stats_delta_total'].items()]))
-        print '  %s' % (' '.join(['%s=%d' % (x[0], x[1])
-            for x in src['seq'].items()]))
+                    for x in list(src['stats_delta_total'].items())])))
+        print('  %s' % (' '.join(['%s=%d' % (x[0], x[1])
+            for x in list(src['seq'].items())])))
 
 
     def print_summary(self):
-        for src_id in self.srcs.iterkeys():
+        for src_id in self.srcs.keys():
             self.print_summary_src(src_id)
 
 def parse_args():
@@ -518,7 +518,7 @@ def main(argv):
 
     srcs = SrcTracker()
 
-    print '%s|%s|%s|%s|%s|%s|%s' % ("dnsflow server", "resolver ip", "client ip", "time", "names", "ipv4", "ipv6")
+    print('%s|%s|%s|%s|%s|%s|%s' % ("dnsflow server", "resolver ip", "client ip", "time", "names", "ipv4", "ipv6"))
 
     try:
         for cnt, pkt in enumerate(diter):
@@ -532,15 +532,16 @@ def main(argv):
             elif args.src_summary:
                 if cnt != 0 and cnt % 100000 == 0:
                     srcs.print_summary()
-                    print '-'*40
+                    print('-'*40)
             else:
                 _print_parsed_pkt(pkt)
     except KeyboardInterrupt:
-        print '\nSummary:'
+        print('\nSummary:')
         srcs.print_summary()
     else:
-        print '\nSummary:'
+        print('\nSummary:')
         srcs.print_summary()
+
 
 if __name__ == '__main__':
     main(sys.argv)


### PR DESCRIPTION
Addresses https://deepfield.atlassian.net/browse/DP-2798
The main goal of this PR was to port dnsflow_read.py to python3.

However this was not as simple as simply running py2to3, b/c previously this script had a dependency on python-libpcap, https://sourceforge.net/projects/pylibpcap/files/pylibpcap/0.6.4/, which is both difficult to install, and also is written in python2 and apparently not actively maintained, so we cannot use it with python3.

However, there is a different package, pypcap (https://github.com/pynetwork/pypcap) that has similar support. It wasn't able to support easily the entire full functionality that was previously available, but between that module and `dpkt.pcap`, we are 90+% of the way there. Really the only thing missing, is that if the user is reading dnsflow from a pcap file (not live capturare), then they cannot specify any additional filter, just the default filters of UDP packet + DNSFlow Port (5300) are supported in this mode.

Additionally both python-libpcap and pypcap are imported into python as `import pcap`, which was convenient. As far as I can tell, they are both based on the libpcap C library.

I also deleted a lot of unused methods, so that I didn't have to bother with porting them.

### Before:
```
support@carefree-shockley-master:~/dnsflow$ ./dnsflow_read.py 
  File "./dnsflow_read.py", line 83
    print err
            ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(err)?
support@carefree-shockley-master:~/dnsflow$
```

### After:
Reading from PCAP:
```
support@carefree-shockley-master:~/dnsflow$ sudo ./dnsflow_read.py -r /pipedream/dnsflows/dns.2020-05-29-00-00-00.pcap.gz
dnsflow server|resolver ip|client ip|time|names|ipv4|ipv6
198.108.1.42|0.0.0.0|198.111.165.50|00:00:00|www.wattpad.com.|104.16.2.16,104.16.3.16|
198.108.1.42|0.0.0.0|198.110.49.40|00:00:00|mdmenrollment.apple.com.akadns.net.|17.146.232.35|
198.108.1.42|0.0.0.0|204.38.169.20|00:00:00|gsp-ssl.ls.apple.com.,gsp-ssl.ls-apple.com.akadns.net.,gsp-ssl.ls2-apple.com.akadns.net.|17.167.195.40,17.167.193.43,17.167.195.42,17.167.193.45,17.167.193.41,17.167.195.44|
198.108.1.42|0.0.0.0|161.57.5.6|00:00:00|service.gc.apple.com.akadns.net.|17.173.254.25|
198.108.1.42|0.0.0.0|207.74.72.135|00:00:00|time.windows.com.,time.microsoft.akadns.net.|13.85.70.43|
198.108.1.42|0.0.0.0|204.38.169.20|00:00:00|appspot.l.google.com.|172.217.4.241|
...
198.108.130.5|0.0.0.0|198.109.124.3|00:00:10|mc-5133-342738485.us-west-2.elb.amazonaws.com.|54.245.249.231,54.244.226.98|
198.108.130.5|0.0.0.0|204.38.54.56|00:00:10|www.facebook.com.,star-mini.c10r.facebook.com.|157.240.2.35|
198.108.130.5|0.0.0.0|204.38.54.56|00:00:10|star-mini.c10r.facebook.com.|157.240.2.35|
198.108.130.5|0.0.0.0|207.74.28.67|00:00:10|pxl.jivox.com.|54.243.235.84,54.243.144.48,54.235.147.229,54.225.151.136|
198.108.130.5|0.0.0.0|198.110.49.40|00:00:10|a1441.g4.akamai.net.|192.122.184.147,192.122.184.146|
198.108.130.5|0.0.0.0|208.68.24.21|00:00:10|8.courier-push-apple.com.akadns.net.,pop-namer-north-courier.push-apple.com.akadns.net.|17.249.76.24,17.249.76.18,17.249.76.26,17.249.76.27,17.249.76.22,17.249.76.36,17.249.76.10,17.249.76.8|

Summary:
198.108.1.42:33555
  n_data_pkts=177 n_records=3424 n_stats_pkts=1
  n_data_pkts/s=17.70 n_records/s=342.40 n_stats_pkts/s=0.10
  pkts_captured=0 pkts_received=0 pkts_dropped=0 pkts_ifdropped=0
  pkts_captured/s=0.00 pkts_received/s=0.00 pkts_dropped/s=0.00 pkts_ifdropped/s=0.00
  seq_last=329380701 seq_total=178 seq_lost=0 seq_ooo=0
198.108.130.5:54812
  n_data_pkts=102 n_records=1891 n_stats_pkts=1
  n_data_pkts/s=10.20 n_records/s=189.10 n_stats_pkts/s=0.10
  pkts_captured=0 pkts_received=0 pkts_dropped=0 pkts_ifdropped=0
  pkts_captured/s=0.00 pkts_received/s=0.00 pkts_dropped/s=0.00 pkts_ifdropped/s=0.00
  seq_last=101447903 seq_total=103 seq_lost=0 seq_ooo=0
198.109.36.3:33576
  n_data_pkts=36 n_records=701 n_stats_pkts=1
  n_data_pkts/s=3.60 n_records/s=70.10 n_stats_pkts/s=0.10
  pkts_captured=0 pkts_received=0 pkts_dropped=0 pkts_ifdropped=0
  pkts_captured/s=0.00 pkts_received/s=0.00 pkts_dropped/s=0.00 pkts_ifdropped/s=0.00
  seq_last=30917520 seq_total=37 seq_lost=0 seq_ooo=0
support@carefree-shockley-master:~/dnsflow$ 
```
Live-capture (I couldn't get tcpreplay to work with port 5300 on my vlab, probably some AWS firewall issue, but I did play with the default filter to just filter for UDP packets, and could see that we were correctly translating the packets into "Ethernet" objects, and the rest of the logic I didn't really change, so it should be working the same as before):
```
support@carefree-shockley-master:~/dnsflow$ sudo ./dnsflow_read.py -i lo
dnsflow server|resolver ip|client ip|time|names|ipv4|ipv6
Listening on lo: udp and dst port 5300

```