### PR TITLE
CDT-274: fix handling of ipv6 extension headers

### DIFF
--- a/dnsflow.c
+++ b/dnsflow.c
@@ -607,6 +607,18 @@ udp_check(int pkt_len, struct ip *ip, struct ip6_hdr *ip6)
 		}
 		udphdr = (struct udphdr *) (((u_char *) ip) + ip_hdr_len);
 	} else if (ip6) {
+		// Note that this loop does not provide much utility
+		// when the default base filter using `src port 53` is
+		// in use because the pcap-filter does not know to
+		// offset to the correct location to check for
+		// UDP.src_port when additional extension headers
+		// appear before the UDP section. Thus, we would
+		// likely never encounter a valid IPv6/UDP packet that
+		// would need to enter the while-loop
+		// below. Fortunately, most (if not all) IPv6/UDP/DNS
+		// responses that we are collecting do not have
+		// additional extension headers. We leave this loop in
+		// for exploratory analysis with custom filters.
 		next_hdr = ip6->ip6_nxt;
 		ip_hdr_len = sizeof(struct ip6_hdr);
 		ip6_ext = (struct ip6_ext *)((struct ip6_hdr *)(ip6 + 1));

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -615,7 +615,12 @@ udp_check(int pkt_len, struct ip *ip, struct ip6_hdr *ip6)
 				return (NULL);
 			}
 			next_hdr = ip6_ext->ip6e_nxt;
-			offset = ip6_ext->ip6e_len;
+			offset = (ip6_ext->ip6e_len + 1)*8;
+			// this may occur if we are dealing with garbage data,
+			// which may cause this loop to run forever
+			if (offset <= 0) {
+				return (NULL);
+			}
 			ip_hdr_len +=offset;
 			ip6_ext = (struct ip6_ext *)(((caddr_t)ip6_ext) + offset);
 		}


### PR DESCRIPTION
https://deepfield.atlassian.net/browse/CDT-274

Changes:
 - Fix offset calculation for looping through IPv6 extension headers
 - Add a clause to protect against staying in the while loop forever due to garbage data

TODO:
 - The 'src port 53` pcap filter actually excludes any IPv6 DNS response that uses extension headers even though the DNS part of the packet uses src port 53. We may want to fix this.