### PR TITLE
Add option for specifying all ports to filter

### DIFF
--- a/dcap.c
+++ b/dcap.c
@@ -381,5 +381,3 @@ dcap_get_stats(struct dcap *dcap)
 
 	return (&ds);
 }
-
-

--- a/dnsflow.c
+++ b/dnsflow.c
@@ -1500,24 +1500,27 @@ main(int argc, char *argv[])
 	/* Pcap/event loop */
 	if (pcap_file_read != NULL) {
 		dcap_loop_all(dcap);
-		dcap_close(dcap);
 		dnsflow_pkt_send_data();	/* Send last pkt. */
+		if (pdump != NULL) {
+		    pcap_dump_close(pdump);
+		    pcap_close(pc_dump);
+		}
+		free(data_buf);
+		ds = dcap_get_stats(dcap);
+		dnsflow_print_stats(ds);
+		dcap_close(dcap);
+		dcap = NULL;
 	} else {
 		rv = event_dispatch();
+		// Note that this code will typically not execute, as
+		// there is a signal handler and clean shutdown
+		// callback used during the event loop. If the
+		// event_dispatch function ever returns, it means
+		// there was a serious error.
 		dcap_close(dcap);
+		dcap = NULL;
 		errx(1, "event_dispatch terminated: %d", rv);
 	}
 
-	if (pdump != NULL) {
-		pcap_dump_close(pdump);
-		pcap_close(pc_dump);
-	}
-
-	free(data_buf);
-
-	ds = dcap_get_stats(dcap);
-	dnsflow_print_stats(ds);
-
 	return (0);
 }
-


### PR DESCRIPTION
Adds `-d <port>` command-line option that allows specifying up to 10 unique src ports to include in the pcap filter. When this option is used, the usual default 53 port is left out and must be included manually. Examples:

- single port:
```bash
$ ./dnsflow ... -d 50
... filter ((udp and (src port 50) and ...
```
- multiple ports (input de-duplicated):
```bash
$ ./dnsflow ... -d 50 -d 50 -d 50 -d 50 -d 50 -d 51
... filter ((udp and (src port 50 or src port 51) and ...
```
- bounds checking on values (program exits with error code)
```bash
$ ./dnsflow ... -d -1
dnsflow: values for dns src port filter must be in range [0, 65535]
$ ./dnsflow ... -d 65536
dnsflow: values for dns src port filter must be in range [0, 65535]
```
- at most 10 unique values can be used (program exits with error code)
```bash
$ ./dnsflow ... -d 1 -d 2 ... -d 10 -d 11
dnsflow: at most 10 unique dns filter ports can be assigned
```

Also fixed a memory error where we were reading from free-ed memory at exit. It just happened to work because there were no other memory allocations. Does not impact the event-based run mode that listens on an interface for dns packets.